### PR TITLE
Add delay impact chart

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+streamlit
+pandas
+altair


### PR DESCRIPTION
## Summary
- compute delay impact on cost & timeline
- render Altair line chart for delay analysis
- track dependencies

## Testing
- `python -m py_compile Project_Estimator.py`

------
https://chatgpt.com/codex/tasks/task_e_6841eb319b0c832483ca927c1b4be009